### PR TITLE
 Edit add support Live Display

### DIFF
--- a/drivers/video/msm/mdss/mdss_fb.c
+++ b/drivers/video/msm/mdss/mdss_fb.c
@@ -798,6 +798,9 @@ static ssize_t mdss_set_rgb(struct device *dev,
 	struct mdp_pcc_cfg_data pcc_cfg;
 	u32 copyback = 0;
 
+	struct fb_info *fbi = dev_get_drvdata(dev);
+	struct msm_fb_data_type *mfd = (struct msm_fb_data_type *)fbi->par;
+
 	if (count > 19)
 		return -EINVAL;
 
@@ -824,7 +827,7 @@ static ssize_t mdss_set_rgb(struct device *dev,
 	pcc_cfg.g.g = g;
 	pcc_cfg.b.b = b;
 
-	if (mdss_mdp_pcc_config(&pcc_cfg, &copyback) == 0) {
+	if (mdss_mdp_pcc_config(mfd, &pcc_cfg, &copyback) == 0) {
 		pcc_r = r;
 		pcc_g = g;
 		pcc_b = b;

--- a/drivers/video/msm/mdss/mdss_fb.c
+++ b/drivers/video/msm/mdss/mdss_fb.c
@@ -855,6 +855,8 @@ static DEVICE_ATTR(msm_fb_dfps_mode, S_IRUGO | S_IWUSR,
 	mdss_fb_get_dfps_mode, mdss_fb_change_dfps_mode);
 static DEVICE_ATTR(msm_fb_spec_char_seq, S_IRUGO | S_IWUSR,
 	mdss_fb_get_spec_char_seq, NULL);
+static DEVICE_ATTR(rgb, S_IRUGO | S_IWUSR | S_IWGRP, mdss_get_rgb,
+	mdss_set_rgb);
 static struct attribute *mdss_fb_attrs[] = {
 	&dev_attr_msm_fb_type.attr,
 	&dev_attr_msm_fb_split.attr,
@@ -867,6 +869,7 @@ static struct attribute *mdss_fb_attrs[] = {
 	&dev_attr_msm_fb_panel_status.attr,
 	&dev_attr_msm_fb_dfps_mode.attr,
 	&dev_attr_msm_fb_spec_char_seq.attr,
+	&dev_attr_rgb.attr,
 	NULL,
 };
 

--- a/drivers/video/msm/mdss/mdss_fb.c
+++ b/drivers/video/msm/mdss/mdss_fb.c
@@ -772,6 +772,68 @@ static ssize_t mdss_fb_get_spec_char_seq(struct device *dev,
 	return ret;
 }
 
+static int pcc_r = 32768, pcc_g = 32768, pcc_b = 32768;
+static ssize_t mdss_get_rgb(struct device *dev,
+	struct device_attribute *attr, char *buf)
+{
+	return sprintf(buf, "%d %d %d\n", pcc_r, pcc_g, pcc_b);
+}
+
+/**
+ * simple color temperature interface using polynomial color correction
+ *
+ * input values are r/g/b adjustments from 0-32768 representing 0 -> 1
+ *
+ * example adjustment @ 3500K:
+ * 1.0000 / 0.5515 / 0.2520 = 32768 / 25828 / 17347
+ *
+ * reference chart:
+ * http://www.vendian.org/mncharity/dir3/blackbody/UnstableURLs/bbr_color.html
+ */
+static ssize_t mdss_set_rgb(struct device *dev,
+	struct device_attribute *attr,
+	const char *buf, size_t count)
+{
+	uint32_t r = 0, g = 0, b = 0;
+	struct mdp_pcc_cfg_data pcc_cfg;
+	u32 copyback = 0;
+
+	if (count > 19)
+		return -EINVAL;
+
+	sscanf(buf, "%d %d %d", &r, &g, &b);
+
+	if (r < 0 || r > 32768)
+		return -EINVAL;
+	if (g < 0 || g > 32768)
+		return -EINVAL;
+	if (b < 0 || b > 32768)
+		return -EINVAL;
+
+	pr_info("%s: r=%d g=%d b=%d\n", __func__, r, g, b);
+
+	memset(&pcc_cfg, 0, sizeof(struct mdp_pcc_cfg_data));
+
+	pcc_cfg.block = MDP_LOGICAL_BLOCK_DISP_0;
+	if (r == 32768 && g == 32768 && b == 32768)
+		pcc_cfg.ops = MDP_PP_OPS_DISABLE;
+	else
+		pcc_cfg.ops = MDP_PP_OPS_ENABLE;
+	pcc_cfg.ops |= MDP_PP_OPS_WRITE;
+	pcc_cfg.r.r = r;
+	pcc_cfg.g.g = g;
+	pcc_cfg.b.b = b;
+
+	if (mdss_mdp_pcc_config(&pcc_cfg, &copyback) == 0) {
+		pcc_r = r;
+		pcc_g = g;
+		pcc_b = b;
+		return count;
+	}
+
+	return -EINVAL;
+}
+
 static DEVICE_ATTR(msm_fb_type, S_IRUGO, mdss_fb_get_type, NULL);
 static DEVICE_ATTR(msm_fb_split, S_IRUGO | S_IWUSR, mdss_fb_show_split,
 					mdss_fb_store_split);


### PR DESCRIPTION
I will buy Le Max 2. so I can't test this patches...
could you test this?

P.S. I can't build. because error that is non-related my commits occured.
```
$ make -j8
  CHK     include/config/kernel.release
  CHK     include/generated/uapi/linux/version.h
  CHK     include/generated/utsrelease.h
  CALL    scripts/checksyscalls.sh
  CHK     include/generated/compile.h
  CHK     kernel/config_data.h
  LD      sound/soundcore.o
  LD      drivers/input/input-core.o
  LD      sound/spi/built-in.o
  LD      sound/synth/built-in.o
  CC      sound/last.o
  CC      drivers/input/misc/vl53L0/stmvl53l0_module.o
  CC      sound/usb/card.o
  LD      sound/soc/msm/snd-soc-hostless-pcm.o
  LD      drivers/input/tablet/built-in.o
In file included from drivers/input/misc/vl53L0/inc/vl53l0_api.h:34:0,
                 from drivers/input/misc/vl53L0/stmvl53l0_module.c:37:
drivers/input/misc/vl53L0/inc/vl53l0_platform.h:37:27: fatal error: stmvl53l0-i2c.h: No such file or directory
 #include "stmvl53l0-i2c.h"
                           ^
compilation terminated.
scripts/Makefile.build:257: recipe for target 'drivers/input/misc/vl53L0/stmvl53l0_module.o' failed
make[4]: *** [drivers/input/misc/vl53L0/stmvl53l0_module.o] Error 1
scripts/Makefile.build:402: recipe for target 'drivers/input/misc/vl53L0' failed
make[3]: *** [drivers/input/misc/vl53L0] Error 2
scripts/Makefile.build:402: recipe for target 'drivers/input/misc' failed
make[2]: *** [drivers/input/misc] Error 2
make[2]: *** Waiting for unfinished jobs....
scripts/Makefile.build:402: recipe for target 'drivers/input' failed
make[1]: *** [drivers/input] Error 2
make[1]: *** Waiting for unfinished jobs....
  LD      sound/soc/msm/snd-soc-qdsp6v2.o
  LD      sound/soc/msm/snd-soc-cpe.o
  CC      sound/soc/msm/msm8996.o
  CC      sound/soc/msm/apq8096-auto.o
  CC      sound/usb/clock.o
sound/soc/msm/msm8996.c:34:26: fatal error: device_event.h: No such file or directory
 #include <device_event.h>
                          ^
compilation terminated.
scripts/Makefile.build:257: recipe for target 'sound/soc/msm/msm8996.o' failed
make[3]: *** [sound/soc/msm/msm8996.o] Error 1
make[3]: *** Waiting for unfinished jobs....
  CC      sound/usb/endpoint.o
  CC      sound/usb/format.o
sound/soc/msm/apq8096-auto.c:34:26: fatal error: device_event.h: No such file or directory
 #include <device_event.h>
                          ^
compilation terminated.
scripts/Makefile.build:257: recipe for target 'sound/soc/msm/apq8096-auto.o' failed
make[3]: *** [sound/soc/msm/apq8096-auto.o] Error 1
scripts/Makefile.build:402: recipe for target 'sound/soc/msm' failed
make[2]: *** [sound/soc/msm] Error 2
scripts/Makefile.build:402: recipe for target 'sound/soc' failed
make[1]: *** [sound/soc] Error 2
make[1]: *** Waiting for unfinished jobs....
  CC      sound/usb/helper.o
  CC      sound/usb/mixer.o
  CC      sound/usb/mixer_quirks.o
  CC      sound/usb/pcm.o
  CC      sound/usb/proc.o
  CC      sound/usb/quirks.o
  CC      sound/usb/stream.o
Makefile:945: recipe for target 'drivers' failed
make: *** [drivers] Error 2
make: *** Waiting for unfinished jobs....
  CC      sound/usb/midi.o
  LD      sound/usb/6fire/built-in.o
  LD      sound/usb/bcd2000/built-in.o
  LD      sound/usb/caiaq/built-in.o
  LD      sound/usb/hiface/built-in.o
  LD      sound/usb/misc/built-in.o
  LD      sound/usb/usx2y/built-in.o
  LD      sound/usb/snd-usb-audio.o
  LD      sound/usb/snd-usbmidi-lib.o
  LD      sound/usb/built-in.o
Makefile:945: recipe for target 'sound' failed
make: *** [sound] Error 2
```